### PR TITLE
add support for vue 2 using vue-demi

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,21 +1,29 @@
 {
   "name": "vswr",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
-        "swrev": "^1.9.0"
+        "swrev": "^1.9.0",
+        "vue-demi": "^0.11.2"
       },
       "devDependencies": {
         "tsup": "^4.11.2",
-        "typescript": "^4.3.4"
+        "typescript": "^4.3.4",
+        "vue2": "npm:vue@2"
       },
       "peerDependencies": {
-        "vue": "^3.0.4"
+        "@vue/composition-api": "^1.0.0-beta.1",
+        "vue": "^2.0.0 || ^3.0.4"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
@@ -1172,6 +1180,38 @@
         "@vue/shared": "3.1.2"
       }
     },
+    "node_modules/vue-demi": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.11.2.tgz",
+      "integrity": "sha512-J+X8Au6BhQdcej6LY4O986634hZLu55L0ewU2j8my7WIKlu8cK0dqmdUxqVHHMd/cMrKKZ9SywB/id6aLhwCtA==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue2": {
+      "name": "vue",
+      "version": "2.6.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
+      "dev": true
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -2041,6 +2081,18 @@
         "@vue/runtime-dom": "3.1.2",
         "@vue/shared": "3.1.2"
       }
+    },
+    "vue-demi": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.11.2.tgz",
+      "integrity": "sha512-J+X8Au6BhQdcej6LY4O986634hZLu55L0ewU2j8my7WIKlu8cK0dqmdUxqVHHMd/cMrKKZ9SywB/id6aLhwCtA==",
+      "requires": {}
+    },
+    "vue2": {
+      "version": "npm:vue@2.6.14",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
+      "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ==",
+      "dev": true
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -15,16 +15,26 @@
   "scripts": {
     "dev": "tsup src/index.ts --watch --format esm,cjs,iife --legacy-output",
     "build": "tsup src/index.ts --dts --format esm,cjs,iife --legacy-output --minify",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "switch:2": "vue-demi-switch 2 vue2",
+    "switch:3": "vue-demi-switch 3"
   },
   "peerDependencies": {
-    "vue": "^3.0.4"
+    "@vue/composition-api": "^1.0.0-beta.1",
+    "vue": "^2.0.0 || ^3.0.4"
+  },
+  "peerDependenciesMeta": {
+    "@vue/composition-api": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "tsup": "^4.11.2",
-    "typescript": "^4.3.4"
+    "typescript": "^4.3.4",
+    "vue": "^3.0.4"
   },
   "dependencies": {
-    "swrev": "^1.9.0"
+    "swrev": "^1.9.0",
+    "vue-demi": "^0.11.2"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { SWR, SWRKey, SWROptions, SWRMutateOptions, SWRRevalidateOptions, CacheClearOptions } from 'swrev'
-import { Ref, ref, getCurrentInstance, onUnmounted, watch, watchEffect, computed } from 'vue'
+import { Ref, ref, getCurrentInstance, onUnmounted, watch, watchEffect, computed } from 'vue-demi'
 
 export class VSWR extends SWR {
   /**


### PR DESCRIPTION
This adds support for Vue 2 via [@vue/composition-api ](https://github.com/vuejs/composition-api) plugin. It uses https://github.com/vueuse/vue-demi/.

Vue 2 users will be required to install the composition-api plugin.