### PR TITLE
fix: re-export SWROptions

### DIFF
--- a/src/vswr.ts
+++ b/src/vswr.ts
@@ -9,6 +9,8 @@ import {
 } from 'swrev'
 import { Ref, ref, getCurrentInstance, onUnmounted, watch, computed, ComputedRef, WatchStopHandle } from 'vue'
 
+export { SWROptions } from 'swrev'
+
 export interface SWRResponse<D = any, E = Error> {
   data: Ref<D | undefined>
   error: Ref<E | undefined>

--- a/src/vswr.ts
+++ b/src/vswr.ts
@@ -9,7 +9,7 @@ import {
 } from 'swrev'
 import { Ref, ref, getCurrentInstance, onUnmounted, watch, computed, ComputedRef, WatchStopHandle } from 'vue'
 
-export { SWROptions } from 'swrev'
+export * from 'swrev'
 
 export interface SWRResponse<D = any, E = Error> {
   data: Ref<D | undefined>


### PR DESCRIPTION
This PR:
Re-exported `SWROptions` so that they can be used in query helper functions without having to import them separately from `swrev`